### PR TITLE
Add ThemedImage component to allow different images based on theme

### DIFF
--- a/components/ThemedImage.js
+++ b/components/ThemedImage.js
@@ -1,0 +1,13 @@
+import Image from "next/image";
+import { useTheme } from "next-themes";
+
+export default function ThemedImage({lightImg, darkImg, alt, ...rest}) {
+  const { systemTheme, theme } = useTheme();
+  const currentTheme = theme === "system" ? systemTheme : theme;
+
+  const imgSrc = currentTheme === "dark" ? darkImg : lightImg;
+
+  return (
+    <Image src={imgSrc} alt={alt} {...rest} />
+  )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import { IconContext } from "react-icons";
 import Script from "next/script";
 import { MdHelpOutline } from "react-icons/md";
@@ -17,6 +16,7 @@ import Testimonials from "@components/Testimonials";
 import Alert from "@components/Alert";
 import CallToAction from "@components/CallToAction";
 import UserMini from "@components/user/UserMini";
+import ThemedImage from "@components/ThemedImage";
 import { serverEnv } from "@config/schemas/serverSchema";
 import { BASE_GITHUB_PROJECT_URL, PROJECT_NAME } from "@constants/index";
 
@@ -309,8 +309,9 @@ export default function Home({
                   )}
                 >
                   <div className="aspect-w-5 aspect-h-2 overflow-hidden rounded-lg bg-primary-low relative">
-                    <Image
-                      src={feature.imageSrc}
+                    <ThemedImage
+                      lightImg={feature.imageSrc}
+                      darkImg={feature.imageSrc}
                       alt={feature.imageAlt}
                       className="object-contain object-center"
                       fill={true}


### PR DESCRIPTION
## Changes proposed
Create ThemedImage component which will display different images base on theme.
Use this component for homepage screenshots.
(It currently uses the same image for both while dark mode images are obtained).

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

