### PR TITLE
fix: (issue #7851) increased max length of link display name

### DIFF
--- a/models/Link.js
+++ b/models/Link.js
@@ -20,7 +20,7 @@ const LinkSchema = new mongoose.Schema(
       type: String,
       required: true,
       min: 2,
-      max: 64,
+      max: 128,
     },
     url: {
       type: String,

--- a/pages/account/manage/link/[[...data]].js
+++ b/pages/account/manage/link/[[...data]].js
@@ -214,7 +214,7 @@ export default function ManageLink({ BASE_URL, username, link }) {
                       value={name}
                       required
                       minLength="2"
-                      maxLength="64"
+                      maxLength="128"
                     />
                     <p className="text-sm text-primary-low-medium">
                       For example: <i>Follow me on Twitter</i>


### PR DESCRIPTION
Increases the max length of a link display name from 64 to 128.

## Fixes Issue

Closes #7851 

## Changes proposed

Changes to the following files: models/Links.js and pages/account/manage/link/[[...data]].js to increase maxLength of link display name.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots

Examples of successfully adding display names of 66 characters and 128 characters:

![image](https://github.com/EddieHubCommunity/BioDrop/assets/23248640/42704282-4a1c-4d9b-ab9f-56edadec1e97)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
