### PR TITLE
[fix] overflow issue in repos section

### DIFF
--- a/components/Link.js
+++ b/components/Link.js
@@ -8,7 +8,7 @@ export default function Link({ children, className, rel, ...restProps }) {
       className={
         className
           ? className
-          : "text-primary-medium dark:text-primary-low underline decoration-dotted hover:underline hover:decoration-solid"
+          : "text-primary-medium dark:text-primary-low underline decoration-dotted hover:underline hover:decoration-solid break-all"
       }
       prefetch={false}
       {...restProps}


### PR DESCRIPTION
## Fixes Issue

Closes #8686

## Changes proposed

To fix the issue I added tailwind `break-all` to `Link` component class in order to allow the link name to break and go to new line it it is considered as a only word by the browser
<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots
![Screenshot 2023-08-30 181738](https://github.com/EddieHubCommunity/BioDrop/assets/12759050/5a798335-2009-496d-a444-f1e6f9c6dded)


