### PR TITLE
In Playwright tests, explicitly wait for link clicks to complete

### DIFF
--- a/tests/changelog.spec.js
+++ b/tests/changelog.spec.js
@@ -11,6 +11,7 @@ test("Changelog has title", async ({ page }) => {
 test("Navigate to Changelog", async ({ page }) => {
   await page.goto("/roadmap");
   await page.getByRole("link", { name: "See full list" }).click();
+  await page.waitForLoadState("networkidle");
   await expect(page.locator("h1")).toHaveText("Changelog");
 });
 
@@ -27,6 +28,7 @@ test("Footer link goes to GitHub", async ({ page }) => {
   const getFooter = page.getByText("Powered by EddieHub");
 
   await getFooter.click();
+  await page.waitForLoadState("networkidle");
 
   await expect(page).toHaveURL(/github/);
 });

--- a/tests/discover.spec.js
+++ b/tests/discover.spec.js
@@ -13,6 +13,7 @@ test("Navigate to the Discover page", async ({ page }) => {
     .getByRole("navigation")
     .getByRole("link", { name: "Discover" })
     .click();
+  await page.waitForLoadState("networkidle");
   await expect(page.locator("h1")).toHaveText("Recently updated Profiles");
 });
 

--- a/tests/docs/docs.spec.js
+++ b/tests/docs/docs.spec.js
@@ -12,6 +12,7 @@ test("docs has quickstart link", async ({ page }) => {
   const getStarted = page.locator('h3:has-text("Quickstart")');
 
   await getStarted.click();
+  await page.waitForLoadState("networkidle");
 
   await expect(page).toHaveURL(/quickstart/);
 });

--- a/tests/events.spec.js
+++ b/tests/events.spec.js
@@ -10,6 +10,7 @@ test("Click on events profile in navbar navigates to events page", async ({
     .getByRole("navigation")
     .getByRole("link", { name: "Events" })
     .click();
+  await page.waitForLoadState("networkidle");
   await expect(page).toHaveURL(/\/events/);
 });
 

--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -21,6 +21,7 @@ test("Footer link goes to GitHub", async ({ page }) => {
   const getFooter = page.getByText("Powered by EddieHub");
 
   await getFooter.click();
+  await page.waitForLoadState("networkidle");
 
   await expect(page).toHaveURL(/github/);
 });

--- a/tests/playground.spec.js
+++ b/tests/playground.spec.js
@@ -39,6 +39,7 @@ test("Footer link goes to GitHub", async ({ page }) => {
   const getFooter = page.getByText("Powered by EddieHub");
 
   await getFooter.click();
+  await page.waitForLoadState("networkidle");
 
   await expect(page).toHaveURL(/github/);
 });

--- a/tests/profile.spec.js
+++ b/tests/profile.spec.js
@@ -62,6 +62,7 @@ test.fixme("Link navigates", async () => {
 test("redirect to search when tag clicked", async ({ page }) => {
   await page.goto("/_test-profile-user-6");
   await page.getByRole("button", { name: "Open Source" }).first().click();
+  await page.waitForLoadState("networkidle");
   await expect(page).toHaveURL("search?keyword=open%20source");
 });
 

--- a/tests/repos.spec.js
+++ b/tests/repos.spec.js
@@ -8,6 +8,7 @@ test("Click on repos in navbar navigates to repo page", async ({ page }) => {
     .getByRole("navigation")
     .getByRole("link", { name: "Repos" })
     .click();
+  await page.waitForLoadState("networkidle");
   await expect(page).toHaveURL("/repos");
 });
 

--- a/tests/search.spec.js
+++ b/tests/search.spec.js
@@ -15,6 +15,7 @@ test("Navigate to the Search page", async ({ page }) => {
     .getByRole("navigation")
     .getByRole("link", { name: "Search" })
     .click();
+  await page.waitForLoadState("networkidle");
   await expect(page.locator("h1")).toHaveText("Search");
 });
 


### PR DESCRIPTION
## Changes proposed
Wait on link clicks to complete before checking.
The current way works most of the time, but is entirely based on the testing systems performance.
Explicitly checking should minimize the false failures.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.


