### PR TITLE
fix: All events should show every event instead of no events

### DIFF
--- a/components/user/UserEvents.js
+++ b/components/user/UserEvents.js
@@ -51,11 +51,15 @@ export default function UserEvents({
     if (eventType === "all") {
       return events;
     }
-    let filteredEvents = events.filter((event) => filterByEventType(event, eventType));
+    let filteredEvents = events.filter((event) =>
+      filterByEventType(event, eventType)
+    );
     if (eventType === "future" && filteredEvents.length === 0) {
-      filteredEvents = events.filter((event) => filterByEventType(event, 'all'))
+      filteredEvents = events.filter((event) =>
+        filterByEventType(event, "all")
+      );
     }
-    return filteredEvents
+    return filteredEvents;
   };
   const eventsToShow = getFilteredEvents();
   const filteredEventOptions = eventOptions.filter((option) => {

--- a/components/user/UserEvents.js
+++ b/components/user/UserEvents.js
@@ -51,7 +51,11 @@ export default function UserEvents({
     if (eventType === "all") {
       return events;
     }
-    return events.filter((event) => filterByEventType(event, eventType));
+    let filteredEvents = events.filter((event) => filterByEventType(event, eventType));
+    if (eventType === "future" && filteredEvents.length === 0) {
+      filteredEvents = events.filter((event) => filterByEventType(event, 'all'))
+    }
+    return filteredEvents
   };
   const eventsToShow = getFilteredEvents();
   const filteredEventOptions = eventOptions.filter((option) => {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue [#8700](https://github.com/EddieHubCommunity/BioDrop/issues/8700)

fixes #8700

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

- Added a check that if there is no future events(which is default action), then it shows every **event instead** of showing **No event found**. 

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->
<img width="1271" alt="Screenshot 2023-09-03 at 23 08 12" src="https://github.com/EddieHubCommunity/BioDrop/assets/24509202/8c6246b9-129a-421b-aa00-c53ec69ee819">
Using `/amandamartin-dev` profile as an example. Since this profile doesn't have any future events, which was the default event type. So instead of showing no events, now it shows all events.

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
