### PR TITLE
Don't decode link URLs

### DIFF
--- a/pages/api/profiles/[username]/links/[_id].js
+++ b/pages/api/profiles/[username]/links/[_id].js
@@ -33,7 +33,7 @@ export default async function handler(req, res) {
   }
 
   if (session && session.username === username) {
-    return res.status(200).redirect(decodeURIComponent(link.url));
+    return res.status(200).redirect(link.url);
   }
 
   const date = new Date();
@@ -86,5 +86,5 @@ export default async function handler(req, res) {
     );
   }
 
-  return res.status(201).redirect(decodeURIComponent(link.url));
+  return res.status(201).redirect(link.url);
 }


### PR DESCRIPTION
## Changes proposed
The redirect code for link URLs would decode them.
This may be a leftover from before we used link IDs.
It can create problems from multi-byte characters that are encoded.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

