### PR TITLE
fix: map usermarker link in darkmode

### DIFF
--- a/components/map/UserMarker.js
+++ b/components/map/UserMarker.js
@@ -20,7 +20,10 @@ export default function UserMarker({ user }) {
       <Popup>
         <div className="flex flex-col gap-[5px]">
           <h1 className="font-[600]">
-            <Link href={`${BASE_WEBSITE_URL}${user.properties.username}`}>
+            <Link
+              href={`${BASE_WEBSITE_URL}${user.properties.username}`}
+              className="text-primary-medium underline decoration-dotted hover:underline hover:decoration-solid break-all"
+            >
               {user.properties.name}
             </Link>
           </h1>


### PR DESCRIPTION
Adds the `Link` classes to the `UserMarker` component.

Alternatively it could probably be better to add a prop to `Link` to dynamically disable dark mode text colour.

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Closes #8979 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

![image](https://github.com/EddieHubCommunity/BioDrop/assets/1681525/5ff3fc3c-87b2-4b13-9389-b6f9d8546cc8)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
