### PR TITLE
Fix QR-Code layout cut issue in small screens

### DIFF
--- a/components/Modal.js
+++ b/components/Modal.js
@@ -35,7 +35,7 @@ export default function Modal({
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white dark:bg-primary-high text-left shadow-xl transition-all m-16 sm:w-full sm:max-w-4xl max-h-screen overflow-y-auto">
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white dark:bg-primary-high text-left shadow-xl transition-all sm:m-16 mb-32 sm:mb-0 sm:w-full sm:max-w-4xl max-h-screen overflow-y-auto">
                 <div className="absolute right-0 top-0 hidden pr-4 pt-4 sm:block">
                   <button
                     type="button"


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
fixes #8959 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
Removes the big margin from small screens, so the layout isn't cut.

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
Before: 
![Before fix](https://github.com/EddieHubCommunity/BioDrop/assets/89470104/030fc5c5-5fe5-4673-9b45-9e6952eb9d2b)

After:
![After fix](https://github.com/EddieHubCommunity/BioDrop/assets/89470104/836abc71-30c9-47fa-be14-4761dc82c937)


<!-- Add all the screenshots which support your changes -->

## Note to reviewers
Thank you!
<!-- Add notes to reviewers if applicable -->
