### PR TITLE
Added hover styles on "Github links".

### DIFF
--- a/components/EditOnGithub.js
+++ b/components/EditOnGithub.js
@@ -2,7 +2,7 @@ import { useRouter } from "next/router";
 import { RiCodeSSlashFill, RiEdit2Fill, RiFeedbackLine } from "react-icons/ri";
 
 const className =
-  "hover:bg-primary-low group hover:text-secondary-high dark:hover:text-secondary-high flex w-full text-left rounded-md p-2 gap-x-3 text-sm leading-6 font-semibold text-primary-high dark:text-primary-low-medium";
+  "hover:bg-slate-200 duration-300 group hover:text-secondary-high dark:hover:text-secondary-high flex w-full text-left rounded-md p-2 gap-x-3 text-sm leading-6 font-semibold text-primary-high dark:text-primary-low-medium";
 
 const iconClass = "h-5 w-5 self-center";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "biodrop",
-      "version": "2.15.8",
+      "version": "2.18.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
I've just added a simple hover effect on the docs page "GitHub links" previously which was not mentionable on hover so I just added the hover effect on that. 
Thanks.