### PR TITLE
fix: upgrade the BioDrop CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "@storybook/theming": "^7.2.1",
         "@tomfreudenberg/next-auth-mock": "^0.5.6",
         "babel-loader": "^9.1.3",
-        "biodrop-cli": "^2.5.1",
+        "biodrop-cli": "^2.7.0",
         "eslint": "^8.45.0",
         "eslint-config-next": "^13.4.12",
         "eslint-plugin-storybook": "^0.6.13",
@@ -10502,9 +10502,9 @@
       }
     },
     "node_modules/biodrop-cli": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/biodrop-cli/-/biodrop-cli-2.5.1.tgz",
-      "integrity": "sha512-RdMyrko8dQZzduyCtyJ9KB2rxihLZZ/jfR0+ySVtMqapO33tZ74u/E/7B/UKbkB0enyN7SrJH+kxX3PH6JpGWw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/biodrop-cli/-/biodrop-cli-2.7.0.tgz",
+      "integrity": "sha512-vJjAFgQqSPnT9mfi42wnGNGwIQs/II2IgFu1PK5Qb8RY9LgfhI+LaUe559CJ5xVcFbFznurU3A2IxyM1QcI0zA==",
       "dev": true,
       "dependencies": {
         "axios": "^1.4.0",
@@ -10513,7 +10513,7 @@
         "enquirer": "^2.3.6",
         "json-format": "^1.0.1",
         "open": "^9.1.0",
-        "react-icons": "^4.9.0"
+        "react-icons": "^4.11.0"
       },
       "bin": {
         "biodrop-cli": "src/index.js"
@@ -32682,9 +32682,9 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "biodrop-cli": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/biodrop-cli/-/biodrop-cli-2.5.1.tgz",
-      "integrity": "sha512-RdMyrko8dQZzduyCtyJ9KB2rxihLZZ/jfR0+ySVtMqapO33tZ74u/E/7B/UKbkB0enyN7SrJH+kxX3PH6JpGWw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/biodrop-cli/-/biodrop-cli-2.7.0.tgz",
+      "integrity": "sha512-vJjAFgQqSPnT9mfi42wnGNGwIQs/II2IgFu1PK5Qb8RY9LgfhI+LaUe559CJ5xVcFbFznurU3A2IxyM1QcI0zA==",
       "dev": true,
       "requires": {
         "axios": "^1.4.0",
@@ -32693,7 +32693,7 @@
         "enquirer": "^2.3.6",
         "json-format": "^1.0.1",
         "open": "^9.1.0",
-        "react-icons": "^4.9.0"
+        "react-icons": "^4.11.0"
       },
       "dependencies": {
         "chalk": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@storybook/theming": "^7.2.1",
     "@tomfreudenberg/next-auth-mock": "^0.5.6",
     "babel-loader": "^9.1.3",
-    "biodrop-cli": "^2.5.1",
+    "biodrop-cli": "^2.7.0",
     "eslint": "^8.45.0",
     "eslint-config-next": "^13.4.12",
     "eslint-plugin-storybook": "^0.6.13",


### PR DESCRIPTION
## Changes proposed

Upgrade the BioDrop CLi to 2.7 that adds the support for Font Awesome 6 icons

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.

