### PR TITLE
[BUG] Truncated long urls in /account/statistics page

### DIFF
--- a/pages/account/statistics.js
+++ b/pages/account/statistics.js
@@ -17,36 +17,11 @@ import { abbreviateNumber } from "@services/utils/abbreviateNumbers";
 import Navigation from "@components/account/manage/Navigation";
 import UserMini from "@components/user/UserMini";
 import { PROJECT_NAME } from "@constants/index";
-import { useState } from "react";
 
 const DynamicChart = dynamic(
   () => import("../../components/statistics/StatsChart"),
   { ssr: false }
 );
-
-const ExpandingUrl = ({url}) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-
-  return (
-    url.length > 40?(
-    <>
-      {url.substring(0, 40) + (isExpanded === false ? (" ...") : (""))}
-        
-      {isExpanded && (
-          url.substring(40, url.length)
-      )}
-
-      <div onClick={() => setIsExpanded(prev => !prev)} className="hover:cursor-pointer text-primary-low-high">
-        {isExpanded === false ? ("click to expand") : ("click to collapse")}
-      </div>
-  
-    </>
-    ):(
-      url
-    )
-  )
-    
-}
 
 export async function getServerSideProps(context) {
   const { req, res } = context;
@@ -296,9 +271,9 @@ export default function Statistics({ data, profile, progress, BASE_URL }) {
           <tbody className="divide-y divide-primary-low dark:divide-primary-medium bg-white dark:bg-primary-high">
             {data.links &&
               data.links.individual.map((link) => (
-                <tr key={link.url} className="">
-                  <td className="whitespace-wrap-pre break-words max-sm:max-w-[200px] max-w-lg bg-dark py-4 pl-4 pr-3 text-sm font-medium text-primary-high dark:text-primary-low">
-                    <ExpandingUrl url={link.url} />
+                <tr key={link.url}>
+                  <td className=" truncate break-words max-sm:max-w-[200px] max-w-lg bg-dark py-4 pl-4 pr-3 text-sm font-medium text-primary-high dark:text-primary-low">
+                    {link.url}
                   </td>
                   <td className="whitespace-nowrap px-3 py-4 text-sm text-primary-medium dark:text-primary-low">
                     {abbreviateNumber(link.clicks)}

--- a/pages/account/statistics.js
+++ b/pages/account/statistics.js
@@ -17,11 +17,36 @@ import { abbreviateNumber } from "@services/utils/abbreviateNumbers";
 import Navigation from "@components/account/manage/Navigation";
 import UserMini from "@components/user/UserMini";
 import { PROJECT_NAME } from "@constants/index";
+import { useState } from "react";
 
 const DynamicChart = dynamic(
   () => import("../../components/statistics/StatsChart"),
   { ssr: false }
 );
+
+const ExpandingUrl = ({url}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    url.length > 40?(
+    <>
+      {url.substring(0, 40) + (isExpanded === false ? (" ...") : (""))}
+        
+      {isExpanded && (
+          url.substring(40, url.length)
+      )}
+
+      <div onClick={() => setIsExpanded(prev => !prev)} className="hover:cursor-pointer text-primary-low-high">
+        {isExpanded === false ? ("click to expand") : ("click to collapse")}
+      </div>
+  
+    </>
+    ):(
+      url
+    )
+  )
+    
+}
 
 export async function getServerSideProps(context) {
   const { req, res } = context;
@@ -271,9 +296,9 @@ export default function Statistics({ data, profile, progress, BASE_URL }) {
           <tbody className="divide-y divide-primary-low dark:divide-primary-medium bg-white dark:bg-primary-high">
             {data.links &&
               data.links.individual.map((link) => (
-                <tr key={link.url}>
-                  <td className="md:whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-primary-high dark:text-primary-low sm:pl-6">
-                    {link.url}
+                <tr key={link.url} className="">
+                  <td className="whitespace-wrap-pre break-words max-sm:max-w-[200px] max-w-lg bg-dark py-4 pl-4 pr-3 text-sm font-medium text-primary-high dark:text-primary-low">
+                    <ExpandingUrl url={link.url} />
                   </td>
                   <td className="whitespace-nowrap px-3 py-4 text-sm text-primary-medium dark:text-primary-low">
                     {abbreviateNumber(link.clicks)}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Closes #8952
<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
- Fixed unresponsiveness and overflow of long links
- Added expanding and collapsing feature

## Change requested
- requested to truncate the link instead of the complex solution.

## Final changes

- added truncate class from tailwindCSS as per the recomendations and solve the overflow issue by adding max-width.
- 
<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
Truncated link 👇:
![image](https://github.com/EddieHubCommunity/BioDrop/assets/53367382/1278be09-c361-454f-9d4d-151d1eef31c0)



<!-- Add all the screenshots which support your changes -->

## Note to reviewers

Responsiviness if fixed. I have not seen any issue raised on this so i fixed if without raising an issue. If there are any open issues that I am unable to see about the responsiveness of the link please close it too.
<!-- Add notes to reviewers if applicable -->
