### PR TITLE
Fix avatar size testimonials

### DIFF
--- a/pages/account/manage/testimonials.js
+++ b/pages/account/manage/testimonials.js
@@ -167,15 +167,17 @@ export default function ManageTestimonials({ BASE_URL, testimonials }) {
                         </p>
                       </div>
                       <div className="mt-1 flex items-center gap-x-2 text-xs leading-5 text-primary-medium-low dark:text-primary-low-high">
-                        <div className="w-12">
-                          <FallbackImage
-                            width={100}
-                            height={100}
-                            src={`https://github.com/${testimonial.username}.png`}
-                            fallback={testimonial.username}
-                            alt={testimonial.username}
-                            className="rounded-full bg-primary-low"
-                          />
+                        <div className="flex items-center">
+                          <div className="w-12">
+                            <FallbackImage
+                              width={100}
+                              height={100}
+                              src={`https://github.com/${testimonial.username}.png`}
+                              fallback={testimonial.username}
+                              alt={testimonial.username}
+                              className="rounded-full bg-primary-low"
+                            />
+                          </div>
                         </div>
                         <p className="whitespace-normal">
                           {testimonial.description}

--- a/pages/account/manage/testimonials.js
+++ b/pages/account/manage/testimonials.js
@@ -167,7 +167,7 @@ export default function ManageTestimonials({ BASE_URL, testimonials }) {
                         </p>
                       </div>
                       <div className="mt-1 flex items-center gap-x-2 text-xs leading-5 text-primary-medium-low dark:text-primary-low-high">
-                        <div className="flex items-center">
+                        <div className="flex">
                           <div className="w-12">
                             <FallbackImage
                               width={100}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue 

fixes #8947

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->
Wrapped the profile picture element in a flex div.
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
<img width="1492" alt="image" src="https://github.com/EddieHubCommunity/BioDrop/assets/7535401/587e1ee3-bd9f-4f99-b678-7cde078bfc0b">

<!-- Add all the screenshots which support your changes -->

## Note to reviewers
The testimonials in the account page currently look off from a spacing perspective. I would suggest to also adjust it by using the public testimonials as an example since it looks way better. I think it's best to open another issue for that as it is a bit more broad in scope than the current one.

<!-- Add notes to reviewers if applicable -->
