### PR TITLE
Fix accessibility issues on profile page

### DIFF
--- a/components/Link.js
+++ b/components/Link.js
@@ -3,7 +3,6 @@ import NextLink from "next/link";
 export default function Link({ children, className, rel, ...restProps }) {
   return (
     <NextLink
-      aria-label={children}
       rel={rel ? rel : "noreferrer"}
       className={
         className

--- a/components/form/Label.js
+++ b/components/form/Label.js
@@ -4,7 +4,7 @@ export default function Label({ htmlFor, className = "", ...restProps }) {
   return (
     <label
         htmlFor={htmlFor}
-        className={classNames("dark:text-white hidden md:block mb-2", className)}
+        className={classNames("dark:text-white sr-only md:block mb-2", className)}
         {...restProps}
       >
         {restProps.children}

--- a/components/navbar/Navbar.js
+++ b/components/navbar/Navbar.js
@@ -147,7 +147,7 @@ export default function Navbar() {
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center">
               <div className="flex-shrink-0">
-                <Link href="/">
+                <Link href="/" ariaLabel="BioDrop Home">
                   <LogoWide onClick={() => setIsOpen(false)} width={128} />
                 </Link>
               </div>

--- a/components/navbar/Navbar.js
+++ b/components/navbar/Navbar.js
@@ -147,7 +147,7 @@ export default function Navbar() {
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center">
               <div className="flex-shrink-0">
-                <Link href="/" ariaLabel="BioDrop Home">
+                <Link href="/" aria-label="BioDrop Home">
                   <LogoWide onClick={() => setIsOpen(false)} width={128} />
                 </Link>
               </div>


### PR DESCRIPTION
## Changes proposed
Adding an `aria-label` to links using children adds garbage when children are components.
Using `hidden` on labels removes them from the DOM, changing to `sr-only`.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

![Screen Shot 2023-09-25 at 08 14 43](https://github.com/EddieHubCommunity/BioDrop/assets/35927536/7c9eb6a5-aa28-4d12-a8f7-393d814b4e34)
