### PR TITLE
Fix mobile give us a star banner styling

### DIFF
--- a/components/layouts/Alert.js
+++ b/components/layouts/Alert.js
@@ -3,7 +3,7 @@ import { FaGithub } from "react-icons/fa6";
 export default function Alert() {
   return (
     <div className="flex items-center gap-x-6 bg-gray-900 px-6 py-2.5 sm:px-3.5 sm:before:flex-1">
-      <p className="text-sm leading-6 text-white">
+      <p className="text-sm leading-6 text-white whitespace-nowrap">
         <a
           href="https://github.com/EddieHubCommunity/BioDrop"
           target="_blank"


### PR DESCRIPTION
## Fixes Issue

Closes #9299 

## Changes proposed

- Adjusted the alignment of the "give us a star" banner to enhance readability on mobile devices.
- Addressed the reported issue regarding improper alignment, aiming to improve UI/UX consistency within the application.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

Mobile Original         
 :--------------------:
![Give us star banner](https://github.com/EddieHubCommunity/BioDrop/assets/129386740/fd3d7a8d-1904-4386-8276-eff08b73bad1)

Mobile Updated       
 :--------------------:
![Give us star banner updated](https://github.com/EddieHubCommunity/BioDrop/assets/129386740/89ef0b53-9972-4287-acfb-82892880367b)



## Note to reviewers

<!-- Add notes to reviewers if applicable -->
