### PR TITLE
Update DocsLayout.js

### DIFF
--- a/components/layouts/DocsLayout.js
+++ b/components/layouts/DocsLayout.js
@@ -132,7 +132,7 @@ export default function DocsLayout({ children, title, section, name }) {
 
         <div className="flex flex-grow flex-col sm:flex-row">
           <SideNav navigation={navigation} />
-          <div className="float-none my-0 w-[100%] sm:w-[65%] md:w-[68%] lg:w-[100%] mt-12">
+          <div className="float-none my-0 w-[100%] sm:w-[65%] md:w-[68%] lg:w-[100%] mt-12 overflow-auto">
             <MDXProvider components={ComponentStyle}>
               <div className="w-full max-w-7xl px-4 sm:px-6 lg:px-8 dark:text-white prose">
                 {children}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
 Fixes Images overflowing on events with json docs #9289
Closes #9289 
<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
Adding overflow-auto property 
<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## Screenshots
<img width="944" alt="Screenshot 2023-10-04 172525" src="https://github.com/EddieHubCommunity/BioDrop/assets/143615010/cea08660-7e9d-478d-87d1-7b47749dacb5">

<!-- Add all the screenshots which support your changes -->

## Note to reviewers
It will resolve the issue if the problem persists please let me know I have an alternate solution changing lg:w-[100%] to lg:w-[75%] in the docslayout
<!-- Add notes to reviewers if applicable -->
