### PR TITLE
Changed join to joining

### DIFF
--- a/pages/docs/open-source-roadmap/where.js
+++ b/pages/docs/open-source-roadmap/where.js
@@ -38,8 +38,8 @@ export default function DocsWhere() {
           Communities and members
         </h2>
         <p>
-          Join communities is a great way to find supportive projects. Also the
-          members themselves will have their own Open Source projects.
+          Joining communities is a great way to find supportive projects. Also
+          the members themselves will have their own Open Source projects.
         </p>
         <p>
           Come and geek out with us in the Open Source community EddieHub


### PR DESCRIPTION
Closes #9327 

## Changes proposed

Changed Typo mistake on page https://www.biodrop.io/docs/open-source-roadmap/where, changed `Join` to `Joining`

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## Screenshots
<img width="746" alt="Screenshot 2023-10-09 110930" src="https://github.com/EddieHubCommunity/BioDrop/assets/43419831/bf80d7f9-ad24-49ae-a8b0-10eb66fe5b8f">
