### PR TITLE
navbar overflow issue on mobile menu

### DIFF
--- a/components/navbar/Navbar.js
+++ b/components/navbar/Navbar.js
@@ -232,7 +232,7 @@ export default function Navbar() {
           className={classNames(
             isOpen
               ? "transform translate-y-0 opacity-100"
-              : "transform -translate-y-96 opacity-0",
+              : "transform -translate-y-[26rem] opacity-0",
             "md:hidden z-20 absolute t-0 bg-primary-medium transition-all duration-700 ease-in-out w-full",
           )}
           id="mobile-menu"


### PR DESCRIPTION
Closes #9445

## Fixes Issue
navbar overflow issue on the mobile menu was fixed by increasing the top height.

## Changes proposed

Before: "transform -translate-y-96 opacity-0",
After: "transform -translate-y-[26rem] opacity-0",




<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## Screenshots

![image](https://github.com/EddieHubCommunity/BioDrop/assets/20722868/dc07042c-6025-41ec-a2d8-93a9f12d1941)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
