### PR TITLE
Fixed : Docs URL refresh when using side nav issue #9486

### DIFF
--- a/components/navbar/SideNav.js
+++ b/components/navbar/SideNav.js
@@ -62,8 +62,7 @@ export default function SideNav({ navigation }) {
                         {item.children.map((subItem) => (
                           <li key={subItem.name}>
                             {/* 44px */}
-                            <Disclosure.Button
-                              as="a"
+                            <Link
                               href={subItem.href}
                               className={classNames(
                                 subItem.href.toLowerCase() == pathname &&
@@ -72,7 +71,7 @@ export default function SideNav({ navigation }) {
                               )}
                             >
                               {subItem.name}
-                            </Disclosure.Button>
+                            </Link>
                           </li>
                         ))}
                       </Disclosure.Panel>


### PR DESCRIPTION

## Fixes Issue
Closes #9486 

## Changes proposed

Now, the docs side-nav link click will not refresh the full page. All docs pages will load without refreshing the URL.


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## Video

https://github.com/EddieHubCommunity/BioDrop/assets/49125977/8ef33efd-52c7-475e-b14b-667c4139bab7



