### PR TITLE
Icon copy notification not visible as underlying elements are also vi…

### DIFF
--- a/components/navbar/Navbar.js
+++ b/components/navbar/Navbar.js
@@ -135,11 +135,11 @@ export default function Navbar() {
         className={classNames(
           "relative top-0 bg-primary-high dark:bg-primary-medium",
           session &&
-            session.accountType === "premium" &&
-            "border-b-2 border-tertiary-medium",
+          session.accountType === "premium" &&
+          "border-b-2 border-tertiary-medium",
         )}
       >
-        <div className="z-30 w-full mx-auto px-4 sm:px-6 lg:px-8 relative t-0">
+        <div className="z-0 w-full mx-auto px-4 sm:px-6 lg:px-8 relative t-0">
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center">
               <div className="flex-shrink-0">


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

 BUG : Icon copy notification text is not readable as the underlying elements are also visible. (#9618)

<!-- Example: Closes #31 -->

## Changes proposed
In navbar.js the styling was z-30, which made the nav elements overlap with the notification box, I altered it to z-0, now it works perfectly fine even if irrespective of dark/light mode or in any view port size.👌

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

![biodrop](https://github.com/EddieHubCommunity/BioDrop/assets/86993627/f36dac82-1fa3-4f1e-bf81-dbd487e58ffd)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
