### PR TITLE
Fix [BUG] Icon copy notification text is not readable as the underlying elements are also visible.

### DIFF
--- a/components/navbar/Navbar.js
+++ b/components/navbar/Navbar.js
@@ -135,11 +135,11 @@ export default function Navbar() {
         className={classNames(
           "relative top-0 bg-primary-high dark:bg-primary-medium",
           session &&
-            session.accountType === "premium" &&
-            "border-b-2 border-tertiary-medium",
+          session.accountType === "premium" &&
+          "border-b-2 border-tertiary-medium",
         )}
       >
-        <div className="z-30 w-full mx-auto px-4 sm:px-6 lg:px-8 relative t-0">
+        <div className="w-full mx-auto px-4 sm:px-6 lg:px-8 relative t-0">
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center">
               <div className="flex-shrink-0">
@@ -229,7 +229,7 @@ export default function Navbar() {
             isOpen
               ? "transform translate-y-0 opacity-100"
               : "transform -translate-y-96 opacity-0",
-            "md:hidden z-20 absolute t-0 bg-primary-medium transition-all duration-700 ease-in-out w-full",
+            "md:hidden absolute t-0 bg-primary-medium transition-all duration-700 ease-in-out w-full",
           )}
           id="mobile-menu"
         >


### PR DESCRIPTION
Closes #9618 

## Fixes Issue
This PR fixes #9618 


## Changes proposed

- Removed the unnecessary z index from navbar and now the Icon copy notification shows over the navbar as it should and text in the icon notification is readable properly.


## Screenshots
Here is a screenshot after my fix:
![image](https://github.com/EddieHubCommunity/BioDrop/assets/33797909/675788f0-c931-46a5-9092-2f2ab0285b56)


