### PR TITLE
fix: typo in footer links

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -22,7 +22,7 @@ export default function Footer() {
       { name: "Map", href: "/map", external: false },
       { name: "Login", href: "/auth/signin", external: false },
       {
-        name: "Open Souce Roadmap",
+        name: "Open Source Roadmap",
         href: "/docs/open-source-roadmap",
         external: false,
       },


### PR DESCRIPTION
## Fixes Issue

Closes #9653 

## Changes proposed

- Fixed a typo mistake in Footer section for Open **_Souce_** Roadmap to Open **_Source_** Roadmap link

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

### Before

![image](https://github.com/EddieHubCommunity/BioDrop/assets/57263951/837ff2ed-8c1d-4c18-a91d-83a3419d97b5)

### After

![image](https://github.com/EddieHubCommunity/BioDrop/assets/57263951/bf0c83a5-87d2-46eb-b588-767e7ce64d97)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
