### PR TITLE
fix: Navbar overlaps with Icon notification

### DIFF
--- a/components/layouts/MultiLayout.js
+++ b/components/layouts/MultiLayout.js
@@ -16,7 +16,7 @@ export default function MultiLayout({ settings, children }) {
             <Navbar />
           </>
         )}
-        <main id="main" className="flex-1 dark:bg-dark-2 dark:z-10">
+        <main id="main" className="flex-1 dark:bg-dark-2 dark:z-40">
           {children}
         </main>
         {(!settings ||


### PR DESCRIPTION
## Fixes Issue

Closes #9618 

## Changes proposed

- By increasing the `z-index` of the `<main>` element, the Icon copy notification now displays over the navbar correctly.  
- This fixes the issue where the notification text elements were hidden under the navbar menu. The intended stacking order now functions properly without conflict.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

After Fix:

![image](https://github.com/EddieHubCommunity/BioDrop/assets/57263951/2d37ee82-baf3-4ed5-be3c-42b0943e7001)

To visualize how these z-index values affect the layering,

https://github.com/EddieHubCommunity/BioDrop/assets/57263951/0bee8633-bc1f-4d18-9408-5de30aeed71b

To resolve this issue, after increasing the z-index value in the `<main>` element from 10 to 40. The video displays the notification above the navbar in the layer hierarchy.

https://github.com/EddieHubCommunity/BioDrop/assets/57263951/11d1cbad-1949-4c53-9420-f3ad21bcdde5

## Note to reviewers

Check PR #9652 for full Triage details
