### PR TITLE
fix: navbar menu layering bug in dark mode

### DIFF
--- a/components/navbar/Navbar.js
+++ b/components/navbar/Navbar.js
@@ -229,7 +229,7 @@ export default function Navbar() {
             isOpen
               ? "transform translate-y-0 opacity-100"
               : "transform -translate-y-96 opacity-0",
-            "md:hidden z-20 absolute t-0 bg-primary-medium transition-all duration-700 ease-in-out w-full",
+            "md:hidden dark:z-50 z-20 absolute t-0 bg-primary-medium transition-all duration-700 ease-in-out w-full",
           )}
           id="mobile-menu"
         >


### PR DESCRIPTION
## Fixes Issue

Closes #9731

## Changes proposed

- Increased the `z-index` of the mobile navbar menu element specifically for dark mode to make it stack above the main content.
- The mobile menus are now functioning correctly on dark mode.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

After fix:

![image](https://github.com/EddieHubCommunity/BioDrop/assets/57263951/92f07d12-87fe-4f78-99da-c6d247aa64c0)

## Note to reviewers

This bug was missed to check in PR #9726 