### PR TITLE
Reduce bg-size on :after to fix Safari bug

### DIFF
--- a/styles/animation.module.css
+++ b/styles/animation.module.css
@@ -40,6 +40,7 @@
   }
 
   .glow::after {
+    background-size: 100%; /* remove once animation is supported by MacOS */
     filter: blur(10px);
     opacity: 0.99;
   }

--- a/styles/animation.module.css
+++ b/styles/animation.module.css
@@ -40,7 +40,7 @@
   }
 
   .glow::after {
-    background-size: 100%; /* remove once animation is supported by MacOS */
+    background-size: 100%; /* remove once animation is supported in Safari and SafariOS */
     filter: blur(10px);
     opacity: 0.99;
   }


### PR DESCRIPTION
In Safari a background is shown when adding the `glow` animation effect to the Social Media Buttons (Links Section on Profile). This is due Safari and Safari on iOS currently not supporting animation and transition on CSS pseudo-elements like `:after`, while other browsers do.

![Background visible on button in Safari](https://github.com/EddieHubCommunity/BioDrop/assets/54622834/5889c475-cf55-4020-a2fd-62e70fd7231e)

Resources: https://developer.mozilla.org/en-US/docs/Web/CSS/::after

## Fixes Issue
Closes #9461 

## Changes proposed
By setting the `background-size` to `100%` to the `:after` animation, the bug disappears. Setting the value more or less than `100%` retains the bug, setting it to `0` would remove the glow as a whole, which is neither wanted nor needed. 

💡 Due to this settings, notice that the heavy glow effect is now gone in general in all browsers.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

Please see screenshots of the changes in Safari Browser.

### Before the changes

![Social Media Section showing visible background in Safari when selecting glow animation](https://github.com/EddieHubCommunity/BioDrop/assets/54622834/f4858c62-653b-4f54-ac82-13388ba6f3f7)

### After the changes
![Unwanted background in Safari and heavy glow in all browsers are gone](https://github.com/EddieHubCommunity/BioDrop/assets/54622834/a35ba7a3-0532-4716-bd98-dc9f0641d142)

## Note to reviewers

I added a `/* comment */` to the `line 43` of my changes in case browser support changes in the future and the original effect will not be forgotten. This can be deleted if wished.
