### PR TITLE
feat: New 'Steps to Reproduce' section in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -38,7 +38,7 @@ body:
       value:  | 
         If you know the steps, follow the below format and provide steps to reproduce
 
-        For example, 
+        For example:
 
         1. Go to <replace your> page.
         1. On top right side, close to the <Account> menu

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -31,6 +31,29 @@ body:
     validations:
       required: true
   - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description:  To help us recreate the bug, provide a numbered list of the exact steps taken to trigger the buggy behavior.
+      value:  | 
+        <!--- 
+        
+        If you partially or fully know the steps, follow the bellow format and provide steps to reproduce
+        
+        For example, 
+        
+        1. Go to <replace your> page.
+        1. On top right side, close to the <Account> menu
+        1. Some menu are not working properly.
+        1. continue...
+        
+        If you don't know the steps, enter 
+            "Could not reproduce " or "Need Help 😣" 
+        
+        -->
+    validations:
+      required: true
+  - type: textarea
     id: screenshots
     attributes:
       label: Screenshots

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -36,21 +36,20 @@ body:
       label: Steps to Reproduce
       description:  To help us recreate the bug, provide a numbered list of the exact steps taken to trigger the buggy behavior.
       value:  | 
-        <!--- 
-        
-        If you partially or fully know the steps, follow the bellow format and provide steps to reproduce
-        
+        If you know the steps, follow the below format and provide steps to reproduce
+
         For example, 
-        
+
         1. Go to <replace your> page.
         1. On top right side, close to the <Account> menu
         1. Some menu are not working properly.
-        1. continue...
-        
-        If you don't know the steps, enter 
-            "Could not reproduce " or "Need Help 😣" 
-        
-        -->
+        1. Continue...
+
+        If you don't know exact steps, include any relevant details like:
+
+        - What page you were on...
+        - What you were trying to do...
+        - What went wrong...
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## Fixes Issue

Closes #9742 

## Changes proposed

To add a required "Steps to Reproduce" section in the bug issue template to reduce the workload for maintainers and help them to reproduce bugs more quickly and easily, which will lead to faster fixes.

In `bug.yml` template:

- Added new `Steps to Reproduce` property 
- Added guidelines/instruction in comment line of value.
- This section is mandatory to provide the bug steps.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

YML Github Preview (not from actual user issue creation)

![image](https://github.com/EddieHubCommunity/BioDrop/assets/57263951/4419ac38-457d-4682-8dbe-35e8b75ad7bd)
![image](https://github.com/EddieHubCommunity/BioDrop/assets/57263951/25921b90-8d3e-4863-bbb8-e806fa01c996)
![image](https://github.com/EddieHubCommunity/BioDrop/assets/57263951/6eccec6c-faae-4129-81d0-94b0e3872e23)

## Note to reviewers

I added instruction in comment line of textarea field instead of placeholder. So that, contributor can copy the sample template and provide the steps. In case of placeholder, they need to manually type and it usually disappear when we type something in Textarea.

Please let me know if you have any feedback on whether to use a placeholder or a value for the instructions in comment line.
