### PR TITLE
fix: z-index issue of confirmation dialog modal in dark mode

### DIFF
--- a/components/ConfirmDialog.js
+++ b/components/ConfirmDialog.js
@@ -15,7 +15,7 @@ export default function ConfirmDialog({
     <Transition.Root show={open} as={Fragment}>
       <Dialog
         as="div"
-        className="relative z-10"
+        className="relative z-40"
         initialFocus={cancelButtonRef}
         onClose={setOpen}
       >


### PR DESCRIPTION
## Fixes Issue

Closes #9765

## Changes proposed

- By increasing the base `z-index` style of the Dialog component, the modal now appears above main content properly in dark modes.
- Increased `z-index` value of from 10 to 40.

## Check List (Check all the applicable boxes) 

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

**Before fix:**

![image](https://github.com/EddieHubCommunity/BioDrop/assets/57263951/35dcb150-83a1-42de-8cb2-6447727eebe0)

**After fix:**

![image](https://github.com/EddieHubCommunity/BioDrop/assets/57263951/18f870f1-bc88-4036-b567-c88740960f98)

## Note to reviewers

- I have manually validated that the modal now displays properly when deleting events, links, milestones, and repos.
- Please test that the modal also appears on the testimonials page when deleting a testimonial in dark mode.

## Suggestions 

> Note: Might be a better solution

This issue occurs only in dark mode. Should we use the `dark:z-40` class instead of updating the `z-10` class? I wanted your opinion on the best solution for proceeding further.