### PR TITLE
feat: show current character length on bio

### DIFF
--- a/pages/account/manage/profile.js
+++ b/pages/account/manage/profile.js
@@ -240,9 +240,10 @@ export default function Profile({ BASE_URL, profile, fileExists }) {
                         minLength="2"
                         maxLength="256"
                       />
-                      <p className="text-sm text-primary-medium-low dark:text-primary-low-high">
-                        You can use Markdown syntax.
-                      </p>
+                      <div className="flex justify-between text-sm text-primary-medium-low dark:text-primary-low-high">
+                        <p>You can use Markdown syntax.</p>
+                        <p>{bio.length} / 256</p>
+                      </div>
                     </div>
 
                     <div className="col-span-3 sm:col-span-4">


### PR DESCRIPTION
## Fixes Issue

Closes #9829

## Changes proposed

I've added a character count next to the note `You can use Markdown syntax.` on bio textarea.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<details>
  <summary>Mobile</summary>
  

https://github.com/EddieHubCommunity/BioDrop/assets/22430210/9b7349c5-597e-4abd-9400-539bd840482b


</details>

<details>
  <summary>Desktop</summary>
  

https://github.com/EddieHubCommunity/BioDrop/assets/22430210/2e60609b-3433-4dfb-8bc7-37b447a3a243


</details>

## Note to reviewers
