### PR TITLE
fix: Milestone Icon Overflow by Removing Rounded Styling

### DIFF
--- a/components/user/UserMilestone.js
+++ b/components/user/UserMilestone.js
@@ -31,7 +31,7 @@ export default function UserMilestone({ milestone, isGoal, manage }) {
       <div className="flex space-x-3 grow">
         {milestone.icon && (
           <DisplayIcon
-            className={`h-8 w-8 rounded-full ${manage ? "ml-12" : "ml-0"}`}
+            className={`h-8 w-8 ${manage ? "ml-12" : "ml-0"}`}
           />
         )}
         <div className="flex-1 space-y-1">


### PR DESCRIPTION
## Fixes Issue

Closes #9824

## Changes proposed

- Removed `rounded-full` class from DisplayIcon component
- Confirmed overflow no longer occurs with **FaCodeBranch** and **FaDev** icons as well as other milestone icons I tested.
- Tested on accounts milestones page

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

| Light | Dark | 
|---|---|
| ![image](https://github.com/EddieHubCommunity/BioDrop/assets/57263951/5f265e30-be2b-4e1d-8e33-dba254ad75dc)  | ![image](https://github.com/EddieHubCommunity/BioDrop/assets/57263951/087f4ca7-7433-4c54-a587-63064d2da10d) |