### PR TITLE
[Fix]: Dragging Input field for Tags gives Error

### DIFF
--- a/components/tag/TagsInput.js
+++ b/components/tag/TagsInput.js
@@ -80,27 +80,29 @@ export default function TagsInput({
         additionalMessage={showNotification.additionalMessage}
       />
       <label htmlFor="tags">Tags</label>
-      <ReactSortable
-        tag="ul"
-        list={tags}
-        setList={setTags}
-        swap
-        role="list"
-        className="flex flex-wrap items-center gap-x-4 gap-y-2 border-primary-medium-low mt-3 border-2 transition-all duration-250 ease-linear rounded px-6 py-2 mb-2 w-full dark:bg-primary-high focus-within:border-tertiary-medium hover:border-tertiary-medium"
-      >
-        {tagItems}
-        <li className="flex-1 basis-1/5">
-          <Input
-            name="tags"
-            className="w-full text-sm rounded-md font-mono outline-none dark:bg-primary-high focus:ring-0 focus:border-tertiary-medium focus:outline-0 p-1 hover:border-tertiary-medium"
-            ref={inputRef}
-            type="text"
-            placeholder="type tag..."
-            onKeyUp={handleKeyUp}
-            onKeyDown={handleKeyDown}
-          />
-        </li>
-      </ReactSortable>
+      <div className="flex-1 basis-1/5 my-2">
+        <Input
+          name="tags"
+          className="w-full text-sm rounded-md font-mono outline-none dark:bg-primary-high focus:ring-0 focus:border-tertiary-medium focus:outline-0 p-1 hover:border-tertiary-medium p-2"
+          ref={inputRef}
+          type="text"
+          placeholder="type tag..."
+          onKeyUp={handleKeyUp}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
+      {tagItems.length > 0 && (
+        <ReactSortable
+          tag="ul"
+          list={tags}
+          setList={setTags}
+          swap
+          role="list"
+          className="flex flex-wrap items-center gap-x-4 gap-y-2 border-primary-medium-low mt-3 border-2 transition-all duration-250 ease-linear rounded px-6 py-2 mb-2 w-full dark:bg-primary-high focus-within:border-tertiary-medium hover:border-tertiary-medium"
+        >
+          {tagItems}
+        </ReactSortable>
+      )}
     </>
   );
 }


### PR DESCRIPTION
Fixes #9869 

## Changes proposed

- [X] My code follows the code style of this project.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots

Screenshot 1: 

<img width="960" alt="SS1" src="https://github.com/EddieHubCommunity/BioDrop/assets/43419831/d895cf3c-3496-4837-ba2c-8b018fdcf872">
Above image shows the case when no tags are added to profile or events page. In this case the tags section is hidden.

Screenshot 2:

<img width="960" alt="SS2" src="https://github.com/EddieHubCommunity/BioDrop/assets/43419831/24878f42-a94c-4a03-8123-9227fb5867f7">
This images shows visibility of the tags section when tags are added.

