### PR TITLE
fix: Image "BioDrop screenshot of statistics" responsiveness

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -246,6 +246,7 @@ export default function Home({
             <Image
               src="https://user-images.githubusercontent.com/109926117/234534981-9db096eb-dc79-4310-a7a6-e7fd46799dff.png"
               alt="BioDrop screenshot of statistics"
+              className="w-full"
               width="600"
               height="300"
             />


### PR DESCRIPTION
It was not fully fit in the container in tablet views.

Closes #10110 

## Changes proposed

I just added className="w-full" in that image.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<img width="967" alt="Screenshot 2024-01-08 at 4 04 15 PM" src="https://github.com/EddieHubCommunity/BioDrop/assets/118199354/cc57a6f9-29db-4a41-983c-6e3aec0168bc">
