### PR TITLE
fix: remove avatar & type keys from json files.

### DIFF
--- a/data/Prashanth-bokkala.json
+++ b/data/Prashanth-bokkala.json
@@ -1,9 +1,6 @@
 {
   "name": "Prashanth Bokkala",
-  "displayStatusPublic": true,
-  "type": "public",
   "bio": "I'm a passionate frontend developer on a journey to master React. Currently immersed in the world of web development, I enjoy crafting user-friendly interfaces that bring ideas to life. Eager to learn and contribute, I'm dedicated to staying on top of the latest technologies. Let's build something amazing together!",
-  "avatar": "https://github.com/Prashanth-bokkala.png",
   "tags": [
     "frontend",
     "JavaScript",

--- a/data/gekkowrld.json
+++ b/data/gekkowrld.json
@@ -1,7 +1,6 @@
 {
   "name": "Gekko Wrld",
   "bio": "Partly gekko, partly human! Building software with the speed and agility of a gekko. Join me in my quest to conquer the digital wrld, one byte at a time!",
-  "avatar": "https://github.com/gekkowrld.png",
   "links": [
     {
       "name": "Follow me on Twitter",


### PR DESCRIPTION
## Changes proposed
- Did a check and found `avatar`, `displayStatsPublic`, & `type` keys in these 2 files, which are no longer used. 
- Removes these unwanted keys from JSON files.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers
- Please be careful with data PRs too & request contributors to remove `avatar`, `displayStatsPublic`, or `type` keys if used in their `json`,  as they no longer need to set these keys manually in their json.