### PR TITLE
FIX: No padding around 'Select a tab' label in mobile view #10150

### DIFF
--- a/components/event/EventTabs.js
+++ b/components/event/EventTabs.js
@@ -18,7 +18,7 @@ export function EventTabs({ tabs, eventType, onEventTypeChange }) {
           label="Select a tab"
           value={tabs.find((tab) => tab.key === eventType)?.title}
           onChange={(e) => changeTab(e)}
-          className="block w-full rounded-md border-primary-medium-low dark:bg-primary-medium dark:focus:border-secondary-low dark:focus:ring-secondary-low  focus:border-secondary-low focus:ring-secondary-low"
+          className="block w-full rounded-md border-primary-medium-low dark:bg-primary-medium dark:focus:border-secondary-low dark:focus:ring-secondary-low  focus:border-secondary-low focus:ring-secondary-low px-6 py-2 mb-2"
           options={tabs.map((tab) => ({ label: tab.title, value: tab.title }))}
         />
       </div>

--- a/components/event/EventTabs.js
+++ b/components/event/EventTabs.js
@@ -18,7 +18,7 @@ export function EventTabs({ tabs, eventType, onEventTypeChange }) {
           label="Select a tab"
           value={tabs.find((tab) => tab.key === eventType)?.title}
           onChange={(e) => changeTab(e)}
-          className="block w-full rounded-md border-primary-medium-low dark:bg-primary-medium dark:focus:border-secondary-low dark:focus:ring-secondary-low  focus:border-secondary-low focus:ring-secondary-low px-6 py-2 mb-2"
+          className="block w-full rounded-md border-primary-medium-low dark:bg-primary-medium dark:focus:border-secondary-low dark:focus:ring-secondary-low  focus:border-secondary-low focus:ring-secondary-low px-6 py-1 mb-2"
           options={tabs.map((tab) => ({ label: tab.title, value: tab.title }))}
         />
       </div>


### PR DESCRIPTION
  Closes #10150

## Fixes Issue

<!-- Remove this section if not applicable -->

  Closes #10150


## Changes proposed (

The select label in the UI was lacking proper padding, which led to alignment issues on smaller screens. To address this, I've added the following Tailwind CSS utility classes to the label's style: "px-6 py-1 mb-2" in the  "select" tag  inside "EventsTab.js" under the "Events" folder

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

Before
![Screenshot (1213)](https://github.com/EddieHubCommunity/BioDrop/assets/129702251/2372e837-73bd-42dc-b526-5c18aaa1d470)

After
![Screenshot (1214)](https://github.com/EddieHubCommunity/BioDrop/assets/129702251/be267c6d-4e27-4d8a-9260-a6eb7dc7bb58)





## Note to reviewers


