### PR TITLE
Fixed the Issue #10203 - The icon drop-down suggestions are not visible properly

### DIFF
--- a/components/IconSearch.js
+++ b/components/IconSearch.js
@@ -37,7 +37,7 @@ function IconSearch({ selectedIcon, handleSelectedIcon }) {
             <Combobox.Option
               key={icon}
               value={icon}
-              className={`px-3 py-2 flex items-center dark:hover:bg-tertiary-medium/60 hover:bg-secondary-low/40`}
+              className={`px-3 py-2 flex items-center bg-white dark:bg-primary-medium dark:hover:bg-tertiary-medium/60 hover:bg-secondary-low/100`}
             >
               <Icon className="h-5 w-5 mr-2 fill-grey-700 inline align-center justify-center" />{" "}
               <span>{icon}</span>


### PR DESCRIPTION
Closes #10203

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
Normal Mode:
![111](https://github.com/EddieHubCommunity/BioDrop/assets/83969719/6c094cc5-5b4c-4a70-a3b4-da7501d9f016)

Dark Mode:
![222](https://github.com/EddieHubCommunity/BioDrop/assets/83969719/f44ed990-9c5f-4eb7-ae41-6c3ea70359ce)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
I have added a screenshot, and it's working fine in both normal and dark mode.