### PR TITLE
Fix (9738):  Prevent showing the initial state when changing query [search page]

### DIFF
--- a/components/Loading.js
+++ b/components/Loading.js
@@ -1,0 +1,13 @@
+import getIcon from "@components/Icon";
+
+function Loading() {
+  const SpinnerIcon = getIcon('FaSpinner');
+
+  return (
+    <div className="flex justify-center items-center h-full" role="progressbar" aria-valuetext="Loading..." aria-busy="true" aria-live="polite">
+      <SpinnerIcon className="animate-spin h-12 w-12" />
+    </div>
+  )
+}
+
+export default Loading;

--- a/pages/search.js
+++ b/pages/search.js
@@ -269,12 +269,13 @@ export default function Search({
           </h2>
         )}
 
-        {notFound && <Alert type="error" message={notFound} />}
         {
           isLoading ? (
             <div className="h-72">
               <Loading />
             </div>
+          ) : notFound ? (
+            <Alert type="error" message={notFound} />
           ) : (
             <>
               <ul

--- a/pages/search.js
+++ b/pages/search.js
@@ -17,6 +17,7 @@ import {
 } from "@services/utils/search/tags";
 import { PROJECT_NAME } from "@constants/index";
 import Button from "@components/Button";
+import Loading from "@components/Loading";
 
 async function fetchUsersByKeyword(keyword) {
   const res = await fetch(
@@ -76,6 +77,7 @@ export default function Search({
   const { replace, query, pathname } = useRouter();
   const { username, keyword, userSearchParam } = query;
   const [notFound, setNotFound] = useState();
+  const [isLoading, setIsLoading] = useState(false);
   const [users, setUsers] = useState(
     keyword ? filteredUsers : recentlyUpdatedUsers,
   );
@@ -122,6 +124,7 @@ export default function Search({
     }
 
     async function fetchUsers(value) {
+      setIsLoading(true)
       try {
         const res = await fetch(
           `${BASE_URL}/api/search?${new URLSearchParams({
@@ -136,9 +139,11 @@ export default function Search({
         setNotFound();
         setUsers(data.users.sort(() => Math.random() - 0.5));
         setCurrentPage(1);
+        setIsLoading(false)
       } catch (err) {
         setNotFound(err.message);
         setUsers([]);
+        setIsLoading(false)
       }
     }
 
@@ -265,35 +270,45 @@ export default function Search({
         )}
 
         {notFound && <Alert type="error" message={notFound} />}
-        <ul
-          role="list"
-          className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
-        >
-          {users.length < usersPerPage &&
-            users.map((user) => (
-              <li key={user.username}>
-                <UserHorizontal profile={user} input={searchTerm} />
-              </li>
-            ))}
+        {
+          isLoading ? (
+            <div className="h-72">
+              <Loading />
+            </div>
+          ) : (
+            <>
+              <ul
+                role="list"
+                className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
+              >
+                {users.length < usersPerPage &&
+                  users.map((user) => (
+                    <li key={user.username}>
+                      <UserHorizontal profile={user} input={searchTerm} />
+                    </li>
+                  ))}
 
-          {users.length > usersPerPage &&
-            visibleUsers.map((user) => (
-              <li key={user.username}>
-                <UserHorizontal profile={user} input={searchTerm} />
-              </li>
-            ))}
-        </ul>
+                {users.length > usersPerPage &&
+                  visibleUsers.map((user) => (
+                    <li key={user.username}>
+                      <UserHorizontal profile={user} input={searchTerm} />
+                    </li>
+                  ))}
+              </ul>
 
-        {users.length > usersPerPage && (
-          <Pagination
-            currentPage={currentPage}
-            data={users}
-            perPage={usersPerPage}
-            paginate={paginate}
-            startIndex={indexOfFirstUser}
-            endIndex={indexOfLastUser}
-          />
-        )}
+              {users.length > usersPerPage && (
+                <Pagination
+                  currentPage={currentPage}
+                  data={users}
+                  perPage={usersPerPage}
+                  paginate={paginate}
+                  startIndex={indexOfFirstUser}
+                  endIndex={indexOfLastUser}
+                />
+              )}
+            </>
+          )
+        }
       </Page>
     </>
   );

--- a/pages/search.js
+++ b/pages/search.js
@@ -281,19 +281,11 @@ export default function Search({
                 role="list"
                 className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
               >
-                {users.length < usersPerPage &&
-                  users.map((user) => (
-                    <li key={user.username}>
-                      <UserHorizontal profile={user} input={searchTerm} />
-                    </li>
-                  ))}
-
-                {users.length > usersPerPage &&
-                  visibleUsers.map((user) => (
-                    <li key={user.username}>
-                      <UserHorizontal profile={user} input={searchTerm} />
-                    </li>
-                  ))}
+                {(visibleUsers ?? []).map((user) => (
+                  <li key={user.username}>
+                    <UserHorizontal profile={user} input={searchTerm} />
+                  </li>
+                ))}
               </ul>
 
               {users.length > usersPerPage && (


### PR DESCRIPTION
## Fixes Issue

Closes #9738 

## Changes proposed

- Add reusable `Loading` component in the `components` folder (The `Loading` is aligned both, vertically and horizontally inside the parent)
- Set a local state for handling the loading status (set it to `true` when the `fetchUsers` function is called and false when it ends)

Extra:

- Remove duplicate logic for rendering the list of the users
- Render one piece of content at the time by chaining all the `if`s

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

https://github.com/EddieHubCommunity/BioDrop/assets/1851658/8b2863d9-55a6-4d4f-895d-c4fb85ca19fa


## Note to reviewers
Do you think I should include a fix for this warning as well? 

```
./pages/search.js
153:6  Warning: React Hook useEffect has missing dependencies: 'BASE_URL', 'pathname', and 'replace'. Either include them or remove the dependency array.  react-hooks/exhaustive-deps
```
